### PR TITLE
Add gcloud-cloudsql HPA

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.13.2
+version: 0.14.0

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/rimusz/charts
-version: 0.13.1
+version: 0.13.2

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -65,16 +65,21 @@ The following table lists the configurable parameters of the `gcloud-sqlproxy` c
 | `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when no existing secret is used, in this case a new secret will be created holding this service account |
 | `existingSecret`                  | Name of an existing secret to be used for the cloud-sql credentials | `""`                                                            |
 | `existingSecretKey`               | The key to use in the provided existing secret   | `""`                                                                               |
-| `usingGCPController` | enable the use of the GCP Service Account Controller     | `""`                                                                                 |
-| `serviceAccountName` | specify a service account name to use     | `""`                                                                                                  |
+| `usingGCPController`              | enable the use of the GCP Service Account Controller     | `""`                                                                       |
+| `serviceAccountName`              | specify a service account name to use   | `""`                                                                                        |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
+| `autoscaling`                     | Enable CPU/Memory horizontal pod autoscaler | `false`                                                                                 |
+| `autoscaling.minReplicas`         | Autoscaler minimum pod replica count    | `1`                                                                                         |
+| `autoscaling.maxReplicas`         | Autoscaler maximum pod replica count    | `3`                                                                                         |
+| `autoscaling.targetCPUUtilizationPercentage` | Scaling target for CPU Utilization Percentage | `50`                                                                       |
+| `autoscaling.targetMemoryUtilizationPercentage` | Scaling target for Memory Utilization Percentage | `50`                                                                 |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |
-| `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP` |
+| `service.type`                    | Kubernetes LoadBalancer type            | `ClusterIP`                                                                                 |
 | `service.internalLB`              | Create service with `cloud.google.com/load-balancer-type: "Internal"` | Default `false`, when set to `true` you have to set also `service.type=LoadBalancer` |
 | `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
-| `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false` |
-| `networkPolicy.ingress.from`     | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]` |
+| `networkPolicy.enabled`           | Enable NetworkPolicy                    | `false`                                                                                     |
+| `networkPolicy.ingress.from`      | List of sources which should be able to access the pods selected for this rule. If empty, allows all sources. | `[]`                  |
 | `extraArgs`                       | Additional container arguments          | `{}`                                                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
+++ b/stable/gcloud-sqlproxy/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.autoscaling.enabled .Values.resources}}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "gcloud-sqlproxy.name" . }}
+    helm.sh/chart: {{ include "gcloud-sqlproxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ include "gcloud-sqlproxy.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: {{ include "gcloud-sqlproxy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -58,7 +58,7 @@ rbac:
   create: false
 
 ## Specifies service type and option to enable internal LoadBalancer
-## If service.internalLB is true, service.type shoul be: LoadBalancer
+## If service.internalLB is true, service.type should be: LoadBalancer
 service:
   type: ClusterIP
   internalLB: false
@@ -81,7 +81,7 @@ networkPolicy:
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Resources are commente out as sometimes Memory/CPU limit causes spikes in query times
+## Resources are commented out as sometimes Memory/CPU limit causes spikes in query times
 ## https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/168#issuecomment-394099416
 resources: {}
 #  requests:
@@ -90,6 +90,15 @@ resources: {}
 #  limits:
 #    memory: 256Mi
 #    cpu: 256m
+
+## Configure a HorizontalPodAutoscaler for pod autoscaling
+## Requires that resources requests are set above
+autoscaling:
+  enabled: false
+#    minReplicas: 1
+#    maxReplicas: 3
+#    targetCPUUtilizationPercentage: 50
+#    targetMemoryUtilizationPercentage: 50
 
 ## Node selector
 nodeSelector: {}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -91,14 +91,16 @@ resources: {}
 #    memory: 256Mi
 #    cpu: 256m
 
-## Configure a HorizontalPodAutoscaler for pod autoscaling
-## Requires that resources requests are set above
+## Configure a HorizontalPodAutoscaler for pod autoscaling.
+## Requires that resources requests are set above.
 autoscaling:
   enabled: false
-#    minReplicas: 1
-#    maxReplicas: 3
-#    targetCPUUtilizationPercentage: 50
-#    targetMemoryUtilizationPercentage: 50
+#  minReplicas: 1
+#  maxReplicas: 3
+## Only one of target CPU and Memory are required to enable the HPA.
+## The ideal target varies and depends on gcloud-sqlproxy usage. 
+#  targetCPUUtilizationPercentage: 50
+#  targetMemoryUtilizationPercentage: 50
 
 ## Node selector
 nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to rimusz/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR introduces a HorizontalPodAutoscaler into the gcloud-sqlproxy helm chart. This will allow the deployment to scale according to its CPU and Memory usage, and an operator defined threshold. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

n/a

**Special notes for your reviewer**:

n/a

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Changes are documented in the README.md
